### PR TITLE
Document WhiteKernel under "kernels"

### DIFF
--- a/docs/user/kernels.rst
+++ b/docs/user/kernels.rst
@@ -33,6 +33,7 @@ Basic Kernels
     :members:
 
 .. autoclass:: george.kernels.ConstantKernel
+.. autoclass:: george.kernels.WhiteKernel
 .. autoclass:: george.kernels.DotProductKernel
 
 


### PR DESCRIPTION
Although it's equivalent to setting `yerr` in the `GP.compute` method,
it's good to know that `WhiteKernel` exists, e.g., so you can set/optimize
its parameter via the `Kernel` interface.
