### PR TITLE
Feature/variance only

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ build
 python/george/__init__.py
 .coverage
 george/*.cpp
+*.swp

--- a/george/gp.py
+++ b/george/gp.py
@@ -278,12 +278,13 @@ class GP(object):
 
         :param return_values: ``list`` or ``str``
             The desired return values. Can be a list of strings or a single
-            string. Available options are: 'mean', 'cov' and 'var'.
+            string. Available options are: 'mean', 'cov' and 'var'. 'var' only
+            computes the diagonal elements of the covariance matrix, hence it
+            is faster and requires less memory.
 
         :param mean_only:
             DEPRICATED, if ``True`` overwrites the return values as follows:
                 ``['mean']``
-
 
         Returns a tuple ``(mu, cov, var)`` (dependent on ``return_values``) 
         where

--- a/george/kernels.py
+++ b/george/kernels.py
@@ -120,10 +120,10 @@ class Kernel(object):
     def __rmul__(self, b):
         return self.__mul__(b)
 
-    def value(self, x1, x2=None):
+    def value(self, x1, x2=None, diag=False):
         x1 = np.ascontiguousarray(x1, dtype=np.float64)
         if x2 is None:
-            return self.kernel.value_symmetric(x1)
+            return self.kernel.value_symmetric(x1, diag=diag)
         x2 = np.ascontiguousarray(x2, dtype=np.float64)
         return self.kernel.value_general(x1, x2)
 

--- a/george/testing/test_gp.py
+++ b/george/testing/test_gp.py
@@ -55,7 +55,7 @@ def _test_prediction(solver=BasicSolver):
     gp.compute(x)
 
     y = x/x.std()
-    mu, cov = gp.predict(y, x)
+    mu, cov, var_direct = gp.predict(y, x, return_values=['mean','cov','var'])
 
     assert np.allclose(y, mu), \
         "GP must predict noise-free training data exactly ({0}).\n({1})" \
@@ -70,11 +70,18 @@ def _test_prediction(solver=BasicSolver):
         "Variance must vanish at noise-free training points ({0}).\n{1}" \
         .format(solver.__name__, var)
 
+    assert np.allclose(var, var_direct), \
+            "Variance must be equal to the diagonal of the covariance matrix" \
+            " ({0}).\n       var:{1}\nvar_direct:{2}".format(solver.__name__,
+                    var, var_direct)
+
     t = np.array((-.5, .3, 1.2))
     var = np.diag(gp.predict(y, t)[1])
     assert np.all(var > 0), \
         "Variance must be positive away from training points ({0}).\n{1}" \
         .format(solver.__name__, var)
+
+
 
 
 def test_prediction(**kwargs):


### PR DESCRIPTION
I added functionality to only compute the diagonal elements of the predictive covariance matrix, which is a lot faster and slimmer. The main changes are in `_kernel.pyx`, `kernel.py` and `gp.py`. I also changed the signature of  `GP.predict` a bit (not sure if you like it...).
I wasn't able to build the docs, so  I'm not sure if the changes to the doc strings are syntactically okay...