### PR TITLE
Make docs Python 3 compatible (xrange → range)

### DIFF
--- a/docs/_code/model.py
+++ b/docs/_code/model.py
@@ -52,7 +52,7 @@ def lnprob_ind(p, t, y, invar):
 def fit_ind(initial, data, nwalkers=32):
     ndim = len(initial)
     p0 = [np.array(initial) + 1e-8 * np.random.randn(ndim)
-          for i in xrange(nwalkers)]
+          for i in range(nwalkers)]
     sampler = emcee.EnsembleSampler(nwalkers, ndim, lnprob_ind, args=data)
 
     print("Running burn-in")
@@ -91,7 +91,7 @@ def lnprob_gp(p, t, y, yerr):
 def fit_gp(initial, data, nwalkers=32):
     ndim = len(initial)
     p0 = [np.array(initial) + 1e-8 * np.random.randn(ndim)
-          for i in xrange(nwalkers)]
+          for i in range(nwalkers)]
     sampler = emcee.EnsembleSampler(nwalkers, ndim, lnprob_gp, args=data)
 
     print("Running burn-in")
@@ -100,7 +100,7 @@ def fit_gp(initial, data, nwalkers=32):
 
     print("Running second burn-in")
     p = p0[np.argmax(lnp)]
-    p0 = [p + 1e-8 * np.random.randn(ndim) for i in xrange(nwalkers)]
+    p0 = [p + 1e-8 * np.random.randn(ndim) for i in range(nwalkers)]
     p0, _, _ = sampler.run_mcmc(p0, 500)
     sampler.reset()
 

--- a/docs/user/model.rst
+++ b/docs/user/model.rst
@@ -134,7 +134,7 @@ both a burn-in and production chain:
     ndim = len(initial)
     nwalkers = 32
     p0 = [np.array(initial) + 1e-8 * np.random.randn(ndim)
-          for i in xrange(nwalkers)]
+          for i in range(nwalkers)]
     sampler = emcee.EnsembleSampler(nwalkers, ndim, lnprob1, args=data)
 
     print("Running burn-in...")
@@ -303,7 +303,7 @@ As before, let's run MCMC on this model:
     initial = np.array([0, 0, -1.0, 0.1, 0.4])
     ndim = len(initial)
     p0 = [np.array(initial) + 1e-8 * np.random.randn(ndim)
-          for i in xrange(nwalkers)]
+          for i in range(nwalkers)]
     sampler = emcee.EnsembleSampler(nwalkers, ndim, lnprob2, args=data)
 
     print("Running first burn-in...")
@@ -312,7 +312,7 @@ As before, let's run MCMC on this model:
     sampler.reset()
 
     # Re-sample the walkers near the best walker from the previous burn-in.
-    p0 = [p + 1e-8 * np.random.randn(ndim) for i in xrange(nwalkers)]
+    p0 = [p + 1e-8 * np.random.randn(ndim) for i in range(nwalkers)]
 
     print("Running second burn-in...")
     p0, _, _ = sampler.run_mcmc(p0, 250)


### PR DESCRIPTION
`xrange` has been removed from Python 3, so let's have the docs use `range(nwalkers)` instead of `xrange(nwalkers)`.

I will pay for the extra memory this requires in Python 2.
