### PR TITLE
Edited assemble_Matrix line for new HODLR

### DIFF
--- a/include/solver.h
+++ b/include/solver.h
@@ -89,7 +89,7 @@ public:
         // Set up the solver object.
         if (solver_ != NULL) delete solver_;
         solver_ = new HODLR_Tree<HODLRSolverMatrix> (matrix_, n, nleaf_);
-        solver_->assemble_Matrix(diag, tol_, 's', seed);
+        solver_->assemble_Matrix(diag, tol_, 's'); // deleted ", seed" from the end of this entry
 
         // Factorize the matrix.
         solver_->compute_Factor();


### PR DESCRIPTION
When trying to install `george` with the latest version of `HODLR` (https://github.com/sivaramambikasaran/HODLR), I received the following error:

```
void assemble_Matrix(VectorXd& diagonal, double lowRankTolerance, char s) {
       ^
/usr/local/include/HODLR_Tree.hpp:188:7: note:   candidate expects 3 arguments, 4 provided
```

I checked out `HODLR_Tree.hpp` at line 188 and found that i required a "vector", a "float", and a 'char'. 

Then I checked out `./include/solver.h`, and george was sending a "vector", a "float", a 'char', and an 'unsigned int'. 

This is probably from an older behaviour of HODLR. So -- as commented in the .h file -- I deleted the last 'unsigned int' or `seed`. 

Now the installation proceeds successfullly.

Then I used ran "python model.py" in the `.george/docs/_code` directory to check if everything processed correctly.  Indeed, the model.py was successful and all subsequent plots in `.george/docs/_static/model/` are representative of my expectations (and memory from previous usages).

Note: I had to update "models.py" too.

1) I had to change "triangle" to "corner" -- as in "import triangle" became "import corner".  and "triangle.corner" became "corner.corner"

2) Also, I had to change "xrange" into "range" -- I think that this is a python2 vs python3 thing.