### PR TITLE
MAINT: specify pybind11 and numpy in build_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -217,7 +217,7 @@ if __name__ == "__main__":
         long_description=open("README.rst").read(),
         package_data={"": ["README.rst", "LICENSE", "AUTHORS.rst",
                            "HISTORY.rst"]},
-        setup_requires["pybind11", "numpy"],
+        setup_requires=["pybind11", "numpy"],
         install_requires=["numpy", "scipy"],
         include_package_data=True,
         cmdclass=dict(build_ext=build_ext),

--- a/setup.py
+++ b/setup.py
@@ -217,7 +217,8 @@ if __name__ == "__main__":
         long_description=open("README.rst").read(),
         package_data={"": ["README.rst", "LICENSE", "AUTHORS.rst",
                            "HISTORY.rst"]},
-        install_requires=["numpy", "scipy", "pybind11"],
+        setup_requires["pybind11", "numpy"],
+        install_requires=["numpy", "scipy"],
         include_package_data=True,
         cmdclass=dict(build_ext=build_ext),
         classifiers=[


### PR DESCRIPTION
We were trying to build george on a clean Travis environment, and the ``pip install`` failed because ``pybind11`` and ``numpy`` are required in order to run the setup.py script.

I *think* this will fix the issue, though I've not tried it out.