### PR TITLE
Default kernel for when none is given

### DIFF
--- a/george/gp.py
+++ b/george/gp.py
@@ -24,7 +24,8 @@ class GP(ModelSet):
     The basic Gaussian Process object.
 
     :param kernel:
-        An instance of a subclass of :class:`kernels.Kernel`.
+        An instance of a subclass of :class:`kernels.Kernel`. If no kernel 
+        is specified then an EmptyKernel shall be used as default.
 
     :param fit_kernel: (optional)
         If ``True``, the parameters of the kernel will be included in all


### PR DESCRIPTION
There is no reference to which kernel the GP object uses when none is given.