### PR TITLE
add build-requirements with pyproject.tml (no prior manual install of numpy & pybind11)

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
 include README.rst LICENSE HISTORY.rst AUTHORS.rst
 graft george/include
 graft vendor
+include pyproject.toml

--- a/dockerfile
+++ b/dockerfile
@@ -1,0 +1,11 @@
+FROM python:3.7
+
+COPY . ./george
+RUN pip3 install --upgrade pip
+RUN cd ./george && pip3 install .
+
+RUN rm -rf ./george/george
+
+RUN pip3 install pytest
+
+RUN pytest -m ./george/tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools>=40.8.0", "wheel", "numpy", "scipy", "PyYAML", "jinja2",
+    "git+https://github.com/pybind/pybind11.git@07e225932235ccb0db5271b0874d00f086f28423#egg=pybind11"]


### PR DESCRIPTION
- installing george via pip is now possible without prior installation of numpy and pybind11
- pybind11 v2.4.3 doesn´t support this build possibilty since the function get_include always points to the location where the header files are located when it´s installed. Since the package is located in a temporary build directory during the build process, the header files couldn´t be found. The recent master version of pybind11 has a new get_include function that is similar to numpy´s version and enables build requirements. Nevertheless, after the build process, the released 2.4.3 pybind11 version will be used.
- for now a specific master commit is referenced inside pyproject.toml, but that should be changed to the next tagged version. tests are all working under macos and ubuntu (dockerfile is added to root directory)