### PR TITLE
fixing python dtype conversion of tuple(str)

### DIFF
--- a/george/modeling.py
+++ b/george/modeling.py
@@ -78,6 +78,9 @@ class Model(object):
         else:
             # Loop over the kwargs and set the parameter values
             params = []
+            if isinstance(self.parameter_names, str):
+                self.parameter_names = (self.parameter_names,)
+
             for k in self.parameter_names:
                 v = kwargs.pop(k, None)
                 if v is None:


### PR DESCRIPTION
If you create a Model with only one parameter that has more than one character, the GP class will raise an error:

`from george.modeling import Model
import george
import numpy as np

class PolynomialModel(Model):
    parameter_names = ("amp")

    def get_value(self, t):
        t = t.flatten()
        return (t * self.m + self.b +
                self.amp * np.exp(-0.5*(t-self.location)**2*np.exp(-self.log_sigma2)))
model = george.GP(mean=PolynomialModel(amp =-1))
`

This will return 

`    raise ValueError("missing parameter '{0}'".format(k))
ValueError: missing parameter 'a'`

However, if the parameter_names entry is only one character (e.g. 'm') it will work as expected. 
There is a simple solution to this problem:
 use parameter_names = ("amp", )  to force python to create a tuple (instead of str type)

However, this is not documented and, in my opinion, not the intended behaviour for the Model interface. This PR just checks if the self.parameter_names is a string and, in that case, create a tuple.